### PR TITLE
Adaptation for page layout

### DIFF
--- a/src/WebviewAppShared/Pages/Water.razor
+++ b/src/WebviewAppShared/Pages/Water.razor
@@ -8,7 +8,7 @@
 <p>Demo from https://github.com/evanw/webgl-water</p>
 
 <style type="text/css">
-    body { font: 13px/140% Arial, sans-serif; overflow: hidden; background: black; }
+    body { font: 13px/140% Arial, sans-serif; overflow: hidden; background: black; touch-action: none; }
     a { color: inherit; cursor: pointer; }
     
     ul { padding: 0 0 0 20px; }


### PR DESCRIPTION
Now in Chrome and the like all touch-events are set as passive by default (under certain conditions), i.e., they cannot be canceled.
So we should use this css property when dealing with touch-devices, otherwise a warning will appear:
*"Unable to **preventDefault** inside passive event listener due to target being treated as passive."*