### PR TITLE
Fix counter value not reloading from AppState.

### DIFF
--- a/src/WebviewAppShared/Pages/Counter.razor
+++ b/src/WebviewAppShared/Pages/Counter.razor
@@ -10,6 +10,12 @@
 @code {
     private int currentCount = 0;
 
+    protected override void OnInitialized()
+    {
+        currentCount = AppState.Counter;
+        base.OnInitialized();
+    }
+
     private void IncrementCount()
     {
         currentCount++;


### PR DESCRIPTION
When you open the Counter page, increment, then leave and come back, the counter is reset to 0.  However the AppState keeps the increased value.  This leads to confusing results when you click the WinForms button because it returns AppState value, which may be different than the page.  The fix is to re-load AppState Counter value each time you visit Counter page.