### PR TITLE
Correct a small spelling mistake

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Cross platform Blazor Desktop example
 
-This sample shows a Blazor Desktop (using the offical APIs coming in .NET 6) app running in both a web browser and in a WinForms and WPF wrapper. This uses the default Blazor Server template as an example which is a bit prettier than the one on the .NET 6 Preview 2 announcement post.
+This sample shows a Blazor Desktop (using the official APIs coming in .NET 6) app running in both a web browser and in a WinForms and WPF wrapper. This uses the default Blazor Server template as an example which is a bit prettier than the one on the .NET 6 Preview 2 announcement post.
 
 Code shared between the Blazor Desktop app and the Blazor Server apps is in the WebviewAppShared Razor class library.
 


### PR DESCRIPTION
In the first line, The word "official" was written "offical".